### PR TITLE
chore: Add .env.example for firebase client credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,5 +7,5 @@ FIREBASE_MESSAGING_SENDER_ID=your-firebase-messaging-sender-id
 FIREBASE_APP_ID=your-firebase-app-id
 
 # OPTIONAL 
-# uncomment only if you want to keep track of google analytics
+# Uncomment only if you want to keep track of google analytics
 # FIREBASE_MEASUREMENT_ID=


### PR DESCRIPTION
## What this PR does?

I'm creating an `.env` file to store our sensitive information and credentials. In this PR, I've included the `firebaseClient` credentials. Firebase uses this info in authentication processes and we'll need to use it later.

## Authors
@fanny @ArthurFerrao 