### PR TITLE
Add an example firebase admin credentials to the env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,11 @@ FIREBASE_STORAGE_BUCKET=your-firebase-storage-bucket
 FIREBASE_MESSAGING_SENDER_ID=your-firebase-messaging-sender-id
 FIREBASE_APP_ID=your-firebase-app-id
 
+# FIREBASE ADMIN
+# You also need the project_id, which was already passed above.
+FIREBASE_PRIVATE_KEY=your-firebase-private-key
+FIREBASE_CLIENT_EMAIL=your-firebase-client-email
+
 # OPTIONAL 
 # Uncomment only if you want to keep track of google analytics
 # FIREBASE_MEASUREMENT_ID=


### PR DESCRIPTION
**Que problema está resolvendo?**

Adicionei variáveis de configuração para o Firebase Admin no arquivo `.env.example`

**Autores**

@fanny @ArthurFerrao