### PR TITLE
fix: Order Screen cards' sort

### DIFF
--- a/src/components/admin/Dnd/index.tsx
+++ b/src/components/admin/Dnd/index.tsx
@@ -3,7 +3,7 @@ import '@atlaskit/css-reset'
 import { Box, Flex, List, Spacer, Text } from '@chakra-ui/react'
 import { updateStatusOrder } from 'api/order'
 import OrderCard from 'components/admin/Order'
-import React, { memo, useEffect, useState } from 'react'
+import React, { memo, useEffect, useRef, useState } from 'react'
 import {
   DragDropContext,
   Draggable,
@@ -145,14 +145,13 @@ const columnOrder = ['pendente', 'cozinha', 'pronto', 'entregue']
 function DragAndDrop() {
   const { data: ordersData, isLoading } = useFirestoreListQuery<Order>('orders')
   const [stateColumns, setStateColumns] = useState<any>(columns)
-  const [hasStateColumnChanged, setHasStateColumnChanged] =
-    useState<boolean>(false)
   const [winReady, setwinReady] = useState(false)
+  const hasStateColumnChangedRef = useRef(false)
 
   useEffect(() => {
     setwinReady(true)
     // [Workaround] If the state column has changed, we already have this change computed locally, so we don't need to update the stateColumn again with data coming from the DB.
-    if (!ordersData || hasStateColumnChanged) {
+    if (!ordersData || hasStateColumnChangedRef.current) {
       return
     }
     const cols: any = {}
@@ -167,7 +166,7 @@ function DragAndDrop() {
     })
 
     setStateColumns(cols)
-  }, [ordersData, hasStateColumnChanged])
+  }, [ordersData, hasStateColumnChangedRef])
 
   const handleDragEnd = (
     destination: DraggableLocation | undefined,
@@ -181,7 +180,7 @@ function DragAndDrop() {
       destination.droppableId === source.droppableId &&
       destination.index === source.index
     ) {
-      setHasStateColumnChanged(false)
+      hasStateColumnChangedRef.current = false
       return
     }
 
@@ -228,7 +227,7 @@ function DragAndDrop() {
       [newEnd.id]: newEnd,
     }
     setStateColumns(newStateColumns)
-    setHasStateColumnChanged(true)
+    hasStateColumnChangedRef.current = true
     updateStatusOrder(draggableId, destination.droppableId.toUpperCase()).catch(
       (error) => {
         setStateColumns(prevStateColumns)

--- a/src/components/admin/Dnd/index.tsx
+++ b/src/components/admin/Dnd/index.tsx
@@ -146,11 +146,16 @@ function DragAndDrop() {
   const { data: ordersData } = useFirestoreListQuery<Order>('orders')
   const [stateColumns, setStateColumns] = useState<any>(columns)
   const [winReady, setwinReady] = useState(false)
+  // Using ref to avoid render triggers
   const hasStateColumnChangedRef = useRef(false)
 
   useEffect(() => {
     setwinReady(true)
-    // [Workaround] If the state column has changed, we already have this change computed locally, so we don't need to update the stateColumn again with data coming from the DB.
+    // [Workaround] If the state column has
+    // changed, we already have this change
+    // computed locally, so we don't need
+    // to update the stateColumn again with
+    // data coming from the DB.
     if (!ordersData || hasStateColumnChangedRef.current) {
       hasStateColumnChangedRef.current = false
       return

--- a/src/components/admin/Dnd/index.tsx
+++ b/src/components/admin/Dnd/index.tsx
@@ -143,7 +143,7 @@ const columns = {
 const columnOrder = ['pendente', 'cozinha', 'pronto', 'entregue']
 
 function DragAndDrop() {
-  const { data: ordersData, isLoading } = useFirestoreListQuery<Order>('orders')
+  const { data: ordersData } = useFirestoreListQuery<Order>('orders')
   const [stateColumns, setStateColumns] = useState<any>(columns)
   const [winReady, setwinReady] = useState(false)
   const hasStateColumnChangedRef = useRef(false)
@@ -152,6 +152,7 @@ function DragAndDrop() {
     setwinReady(true)
     // [Workaround] If the state column has changed, we already have this change computed locally, so we don't need to update the stateColumn again with data coming from the DB.
     if (!ordersData || hasStateColumnChangedRef.current) {
+      hasStateColumnChangedRef.current = false
       return
     }
     const cols: any = {}
@@ -180,7 +181,6 @@ function DragAndDrop() {
       destination.droppableId === source.droppableId &&
       destination.index === source.index
     ) {
-      hasStateColumnChangedRef.current = false
       return
     }
 


### PR DESCRIPTION
#### Que problema está resolvendo?

[Notion Task](https://www.notion.so/Ordenar-os-pedidos-na-tela-de-pedidos-3c80331e68464efdb22fff6e41116197)

O problema descrito na task do notion, envolvia o problema de que localmente a nossa lógica do drag-and-drop, ordenava corretamente os elementos, no entanto, uma vez que esses dados eram enviados para o DB, o firebase alterava a ordenação dos elementos, causando um efeito de transição estranho na tela, além de confusão dos dados.
Após debugar o componente, cheguei a conclusão de duas possíveis soluções:
1. Apenas reusar os dados provenientes do firebase quando a mudança que ocorreu no banco de dados não tivesse sido causada por uma mudança na coluna, pra fazer isso, foi necessário criar uma nova ref `hasStateColumnChanged` que é setado para `true` quando a chamada da função que altera o db é invocada, e setada para false toda vez que o componente persiste a alteração na coluna.
2. Na nossa hook de `useFirestoreListQuery` adicionar uma nova opção para apenas escutar mudanças na entidade, envolvendo criação ou remoção.(Essa era um pouco mais complexa de fazer, então preferi fazer a ais imples e caso alguém veja algum problema, partir pra essa,)

<!-- Marque o número da issue ou link a task do Jira -->

#### Como pode ser manualmente testado?

https://deploy-preview-51--na-mesa.netlify.app/admin

#### Screenshots

<!-- Se aplicável, se não apague essa seção -->

#### Tipos de mudanças

<!-- Marque com x o que se encaixa nas suas mudanças-->

- [X] Conserta um bug
- [ ] Nova funcionalidade
- [ ] Refatoração de código
- [ ] Atualiza documentação
