### PR TITLE
fix: sidebar and pages overflow

### DIFF
--- a/src/components/admin/Layout/index.tsx
+++ b/src/components/admin/Layout/index.tsx
@@ -5,9 +5,11 @@ import Navbar from '@/components/admin/Navbar'
 
 const Layout: FC = ({ children }) => {
   return (
-    <Flex w="full" h="full">
+    <Flex direction="row" overflow="hidden" maxHeight="100vh">
       <Navbar />
-      {children}
+      <Flex width="full" overflow="auto">
+        {children}
+      </Flex>
     </Flex>
   )
 }

--- a/src/components/admin/Navbar/index.tsx
+++ b/src/components/admin/Navbar/index.tsx
@@ -46,7 +46,9 @@ const Navbar = () => {
   return (
     <Flex
       direction="column"
-      width="xs"
+      backgroundColor="white"
+      minWidth="2xs"
+      maxWidth="2xs"
       paddingX={5}
       paddingY={7}
       borderRight="1px solid"

--- a/src/pages/admin/pedidos/index.tsx
+++ b/src/pages/admin/pedidos/index.tsx
@@ -1,18 +1,16 @@
-import { Center, Box, Heading, Flex } from '@chakra-ui/react'
+import { Heading, Flex } from '@chakra-ui/react'
 import Layout from '@/components/admin/Layout'
 import DragAndDrop from '@/components/admin/Dnd'
 
 export default function Orders() {
   return (
     <Layout>
-      <Center h="100vh" w="100vw">
-        <Flex direction="column" height="100%">
-          <Box padding="40px 30px">
-            <Heading size="lg" fontWeight="light">Pedidos</Heading>
-          </Box>
-          <DragAndDrop />
+      <Flex direction="column" height="full" padding={12}>
+        <Flex paddingBottom={14}>
+          <Heading fontWeight="normal">Pedidos</Heading>
         </Flex>
-      </Center>
+        <DragAndDrop />
+      </Flex>
     </Layout>
   )
 }


### PR DESCRIPTION
#### Que problema está resolvendo?

[Notion Task
](https://www.notion.so/156913d756ef46d69e0f2ec6fe328e11?v=a3d2e65c1b3042d58a41d5a8930c41aa&p=b275588f0cb24c64ab5a123ad754b67c)

Este PR corrige o problema do conteúdo de uma página invadir a sidebar para certos tamanhos de tela. Além disso, a largura da sidebar também estava variando dependendo da página.

#### Como pode ser manualmente testado?

https://deploy-preview-52--na-mesa.netlify.app/admin/pedidos

#### Screenshots

![image](https://user-images.githubusercontent.com/15389384/145038289-a34b2488-452b-4899-a652-83428d0583d4.png)
#### Tipos de mudanças

<!-- Marque com x o que se encaixa nas suas mudanças-->

- [x] Conserta um bug
- [ ] Nova funcionalidade
- [ ] Refatoração de código
- [ ] Atualiza documentação
