### PR TITLE
Adjust status label color

### DIFF
--- a/src/pages/receipt/components/Card/CardFooter.tsx
+++ b/src/pages/receipt/components/Card/CardFooter.tsx
@@ -10,10 +10,10 @@ export type OrderCardFooterProps = {
 
 const StatusLabel = ({ status }: { status: string }) => {
   const getColor: { [key: string]: string } = {
-    Pendente: '#EFA238',
-    'Na cozinha': '#8BA451',
-    Pronto: '#3EA299',
-    Entregue: '#2B2D57',
+    PENDENTE: '#EFA238',
+    COZINHA: '#8BA451',
+    PRONTO: '#3EA299',
+    ENTREGUE: '#2B2D57',
   }
 
   return (


### PR DESCRIPTION
#### Que problema está resolvendo?

O status do pedido do cliente não mudava de cor de acordo com o status. 

#### Como pode ser manualmente testado?

#### Screenshots

https://user-images.githubusercontent.com/33286442/145726099-8a2c8001-6716-4697-8d25-b32de7afff3e.mp4

#### Tipos de mudanças

<!-- Marque com x o que se encaixa nas suas mudanças-->

- [x] Conserta um bug
- [ ] Nova funcionalidade
- [ ] Refatoração de código
- [ ] Atualiza documentação
